### PR TITLE
URI을 주고받는 부분을 수정함

### DIFF
--- a/coU/Assets/Scene/Scripts/ProcessDeepLinkMngr.cs
+++ b/coU/Assets/Scene/Scripts/ProcessDeepLinkMngr.cs
@@ -46,21 +46,24 @@ public class ProcessDeepLinkMngr : MonoBehaviour
         // In this example, the app expects a link formatted like this:
         // unitydl://mylink?scene1
         // 42://coU?scene=scene1&name=""&categoryMain=""&categorySub=""
+		
+		string sceneName = "StoreScene";
+		// 현재 방식
+		// ("https://exgs.github.io/yunsleeMap/urlScheme.html?{0},{1},{2}",name,categoryMain,categorySub);
         string query = url.Split("?"[0])[1];
         PrimaryKeys pk = new PrimaryKeys();
-        string[] parameters = query.Split("&"[0]);
-        if (parameters.Length != 4)
+        string[] parameters = query.Split(","[0]);
+        if (parameters.Length != 3)
         {
             print("잘못된 URL Scheme 입니다." + "파라미터 갯수를 확인해주세요");
             // 이런 메세지가 toast로 나오도록 해야함.
             // toast에 마음대로 호출할 수 있는 함수를 만드는 것도 고려사항임
-
             Application.Quit();
             // 기기 별로 종료함수가 다른 것도 함수로 만들어놔야함.
         }
         else
         {
-            pk.scene = parameters[0];
+            pk.scene = sceneName;
             pk.name = parameters[1];
             pk.categoryMain = parameters[2];
             pk.categorySub = parameters[3];
@@ -69,6 +72,7 @@ public class ProcessDeepLinkMngr : MonoBehaviour
         if (validScene == true)
         {
             StoreSceneManager.storeName = pk.name;
+			StoreSceneManager.categoryMain = pk.categoryMain;
             StoreSceneManager.categorySub = pk.categorySub;
             SceneManager.LoadScene(pk.scene);
 

--- a/coU/Assets/Scene/Scripts/ShareBtnClick.cs
+++ b/coU/Assets/Scene/Scripts/ShareBtnClick.cs
@@ -7,12 +7,15 @@ public class ShareBtnClick : MonoBehaviour
 	public void ShareBtnOnClick()
 	{
 		string subject = "42_coU";
-		string scene = "StoreScene";
+		// string scene = "StoreScene";
 		string name = StoreSceneManager.storeName;
 		string categoryMain = StoreSceneManager.categoryMain;
 		string categorySub = StoreSceneManager.categorySub;
-		string uri = string.Format("https://exgs.github.io/yunsleeMap/urlScheme.html?scene={0}&name={1}&categoryMain={2}&categorySub={3}",
-							scene, name, categoryMain, categorySub);
+		// 카테고리메인에 "레스토랑&카페", 카테고리서브 "카페/디저트" &, / 쓰는 것을 조심해야함.
+		// string uri = string.Format("https://exgs.github.io/yunsleeMap/urlScheme.html?scene={0}&name={1}&categoryMain={2}&categorySub={3}",
+		// 					scene, name, categoryMain, categorySub);
+		string uri = string.Format("https://exgs.github.io/yunsleeMap/urlScheme.html?{0},{1},{2}",
+		name, categoryMain, categorySub);
 		print(subject);
 		print(uri);
 #if UNITY_ANDROID && !UNITY_EDITOR


### PR DESCRIPTION
# 문제
URI에 정보를 담아서 보내는데 구분자로 사용하고 있는 `&`, `/` 이 DB의 Value 값에 포함이 되어있음
현재 &으로 정보를 구분하기때문에 문제가 되고 있었다.
![스크린샷 2021-10-20 오후 2 37 37](https://user-images.githubusercontent.com/56223639/138034276-58fddb1e-3e2d-48c8-8bce-00b57b292677.png)
# 해결
1. `,` 를 구분자로 설정하였다. (name, categoryMain, categorySub의 값에서는 보이지않았음)
2. 추가로 Scene은 항상 StoreScene이 켜질 것이기 때문에 보내는 정보에서 제외하였다.
