### PR TITLE
미니캔버스 기능 추가

### DIFF
--- a/coU/Assets/Scene/Scripts/putMarkerManager.cs
+++ b/coU/Assets/Scene/Scripts/putMarkerManager.cs
@@ -57,7 +57,7 @@ public class putMarkerManager : MonoBehaviour
             {
                 canvas.SetActive(true);
                 Transform arTransform = getARTransform();
-                canvas.transform.rotation = Quaternion.Euler(-arTransform.forward);
+				canvas.transform.forward = arTransform.forward;
 
                 float distance = Vector3.Distance(arTransform.position, canvas.transform.position);
                 if (distance > (distanceRadius / 2))
@@ -165,7 +165,7 @@ public class putMarkerManager : MonoBehaviour
             
             Transform arTransform = getARTransform();
             canvas.transform.localPosition = rawLocation;
-            canvas.transform.rotation = Quaternion.Euler(-arTransform.forward);
+			canvas.transform.forward = arTransform.forward;
             canvas.name = it.name;
             canvas.SetActive(false);
         }


### PR DESCRIPTION
# 해결한 내용
1. 미니 캔버스가 뒤집혀 나오는 것 해결하기  
ARcamera와 forward 방향을 일치시킴(캔버스를 뒤집어 놓으면 버튼 이벤트는 눌리지 않는다.)
2. 거리에 따라서 미니캔버스 투명도 다르게 주기  
inspector에서 설정한 거리를 x라고하자, 0<y<x/2 에서는 미니캔버스 디폴트값을 가진다.  
x/2<y<x에서는 디폴트값부터 선형으로 투명도가 증가하여, x 위치에서는 투명도 0으로 한다.