### PR TITLE
Fix: MaxstScene Escape키 클릭 코드 수정

### DIFF
--- a/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System;
 
 using TMPro; // public TextMeshProUGUI 쓰기위함 -> InputField-TextMeshPro
+using UnityEngine.SceneManagement;
 
 public class MaxstSceneManager : MonoBehaviour
 {
@@ -167,7 +168,7 @@ public class MaxstSceneManager : MonoBehaviour
 		// 2021/10/18 hyojlee
 		// MaxstScene에서 뒤로가기 연속 클릭 시 앱 종료하는 부분
 		// 한 번 누르면 종료하지 않고 안드로이드의 토스트 메시지 뜨도록 함
-		if (Input.GetKeyDown(KeyCode.Escape))
+		if (Input.GetKeyDown(KeyCode.Escape) && SceneManager.sceneCount < 2)
 		{
 			backCount++;
 			if (!IsInvoking("ResetBackCount"))

--- a/coU/Assets/Scene/Scripts/Scene/StoreSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/StoreSceneManager.cs
@@ -141,7 +141,10 @@ public class StoreSceneManager : MonoBehaviour
         SceneInfo before = Stack.Instance.Pop();
         string beforePath = SceneUtility.GetScenePathByBuildIndex(before.beforeScene);
         if (beforePath.Contains("MaxstScene"))
+        {
+            Stack.Instance.Clear();
             SceneManager.UnloadSceneAsync("StoreScene");
+        }
         else
         {
             if (beforePath.Contains("SearchScene"))

--- a/coU/Assets/Scene/Scripts/TopBtnClick.cs
+++ b/coU/Assets/Scene/Scripts/TopBtnClick.cs
@@ -39,7 +39,7 @@ public class TopBtnClick : MonoBehaviour
         {
             Stack.Instance.Clear();
             SceneManager.UnloadSceneAsync("StoreScene");
-             return;
+            return;
         }
         
         if (beforePath.Contains("StoreScene"))


### PR DESCRIPTION
1. StoreSceneManager.cs에서 수정한 내용
   이전 씬이 MaxstScene이라면 Pop한 이후에 스택 사이즈는 0이겠지만 혹시 모를 경우를 대비해 StoreScene을 Unload하기 전에 스택을 비워줌.

2. TopBtnClick.cs에서 수정한 내용
   코드 라인 맞춰줌.

3. MaxstSceneManager.cs에서 수정한 내용
   MaxstScene에서 StoreScene을 로드할 때 additive 모드로 추가하기 때문에 핸드폰의 뒤로가기 버튼 클릭 시 MaxstSceneManager.cs의 Update()함수에 if(Input.GetKeyDown(KeyCode.Escape))도 true가 되고 StoreSceneManager.cs에서도 true가 되어 문제가 발생했다. 두 곳에서 모두 실행되기 때문에.
   => MaxstSceneManager.cs에서는 로드된 씬의 개수가 2개 미만, 즉 MaxstScene 하나일 때에만 실행되도록 수정함.