### PR TITLE
처음 인식한 위치(B1,1F,B2)에 따라서 상점의 미니 캔버스를 한번에 생성시킴 

### DIFF
--- a/coU/Assets/Scene/Scripts/PutMarkerManager.cs
+++ b/coU/Assets/Scene/Scripts/PutMarkerManager.cs
@@ -20,7 +20,7 @@ public class PutMarkerManager : MonoBehaviour
     [SerializeField]
     private float distanceRadius = 20.0f;
     public static string floor = "B1"; // TODO: Trackable에서 인식하는 층수가 들어가야 함.
-    private List<GameObject> canvasList = null;
+    private List<GameObject> canvasList = new List<GameObject>();
 
     class LinearTransform
     {
@@ -39,10 +39,13 @@ public class PutMarkerManager : MonoBehaviour
 
     void timetoDraw()
     {
-        string query = "Select * from Stores Where floor = '" + floor + "' group by tntSeq order by `index`";
-        List<Store> stores = GetDBData.getStoresData(query);
-        drawStore(stores, floor);
-        initAlpha = canvasList[0].GetComponentInChildren<Image>().color.a;
+        if (floor != "OUTDOOR")
+        {
+            string query = "Select * from Stores Where floor = '" + floor + "' group by tntSeq order by `index`";
+            List<Store> stores = GetDBData.getStoresData(query);
+            drawStore(stores, floor);
+            initAlpha = canvasList[0].GetComponentInChildren<Image>().color.a;
+        }
     }
 
     void drawTransparent()

--- a/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
@@ -227,8 +227,7 @@ public class MaxstSceneManager : MonoBehaviour
 					eachTrackable.gameObject.SetActive(isLocationInclude);
 				}
 				panelBackground.SetActive(false);
-				string nomeaning = "landmark_coex_";
-				string substr = currentLocalizerLocation.Substring(currentLocalizerLocation.IndexOf(nomeaning) + nomeaning.Length).ToUpper();
+				string substr = currentLocalizerLocation.Substring(currentLocalizerLocation.LastIndexOf('_') + 1).ToUpper();
 				PutMarkerManager.floor = (substr == "F1") ? "1F" : substr;
 				disableRenderer(currentLocalizerLocation);
 				if (naviStart == true)


### PR DESCRIPTION
## 테스트하는데에는 문제 없음

## 문제점
한번 인식된 층에 대해서 고정적임. 층의 변경을 아예 고려하지 않음.
테스트용에서는 문제가 없어서 PR을 올렸고, 비동기 방식으로 5~10초 마다 위치를 재 판단하는 코드를 작성하고자 함(같은 브랜치에서 작업할 예정)