### PR TITLE
Fix: 네비게이션 이용 중 도착 시 캔버스 forward 방향 arcamera와 같도록 변경

### DIFF
--- a/coU/Assets/MaxstAR/VPS/VPSStudio/Path/NavigationController.cs
+++ b/coU/Assets/MaxstAR/VPS/VPSStudio/Path/NavigationController.cs
@@ -231,10 +231,11 @@ public class NavigationController : MonoBehaviour
         destination.transform.position = first + new Vector3(0f, 2f, 0f);
         destination.transform.eulerAngles = destination.transform.eulerAngles + Quaternion.LookRotation(vec).eulerAngles ;
         destination.transform.parent = naviGameObject.transform;
-        Vector3 v3 = arrowItems[arrowItems.ToArray().Length - 1].transform.forward;
-        destination.transform.forward = -v3;
+        //Vector3 v3 = arrowItems[arrowItems.ToArray().Length - 1].transform.forward;
+        //destination.transform.forward = -v3;
         destination.transform.rotation *= Quaternion.Euler(new Vector3(-80f, 0f, 0f));
         destination.name = "destination";
+        MaxstSceneManager.chkNavi = true;
         //
 
         return naviGameObject;

--- a/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
@@ -48,6 +48,10 @@ public class MaxstSceneManager : MonoBehaviour
 	int backCount = 0;
 	GameObject panelBackground;
 
+	//hyojlee 2021.10.23
+	public static bool chkNavi = false;
+	GameObject destination = null;
+
 	void Awake()
 	{
 		if (vPSTrackablesList == null)
@@ -182,6 +186,13 @@ public class MaxstSceneManager : MonoBehaviour
 #endif
 			}
 			Toast.Instance.ShowToastMessage("한 번 더 누르시면 종료됩니다.", 250);
+		}
+
+		//hyojlee 2021.10.23
+		if (chkNavi)
+		{
+			destination = destination == null ? GameObject.Find("destination").gameObject : destination;
+			destination.transform.forward = arCamera.transform.forward;
 		}
 		TrackerManager.GetInstance().UpdateFrame();
 
@@ -479,6 +490,7 @@ public class MaxstSceneManager : MonoBehaviour
 
         if (panelNavi.active)
         {
+			chkNavi = false;
             panelNavi.SetActive(false);
             panelOn.SetActive(true);
 			if (GameObject.Find("Navigation").gameObject != null)


### PR DESCRIPTION
네비게이션 사용 중 도착 지점을 나타내는 캔버스를 마지막 화살표가 보는 반대 방향으로 주려고 했으나 의도대로 되지 않았음
따라서 미니 캔버스처럼 arcamera의 forward를 따르도록 수정