### PR TITLE
Bug: 씬전환시 찰나의 순간에 뒤에서 돌고있는 씬이 보여지는 문제

### DIFF
--- a/coU/Assets/Scene/Scripts/LoginBtnClick.cs
+++ b/coU/Assets/Scene/Scripts/LoginBtnClick.cs
@@ -59,13 +59,12 @@ public class LoginBtnClick : MonoBehaviour
 		//
 		if (LoginSceneManager.isLogin == true)
 		{
-			// 로그인 버튼을 눌렀든, 우리매장 홍보하기를 눌렀든 일단 LoginScene은 
-			SceneManager.UnloadSceneAsync("LoginScene");
 			// 로그인이 된 다음에 씬전환
 			if (LoginSceneManager.isAdvertise) // 1. 우리 매장 홍보하기를 통해 들어온건가?
 				SceneManager.LoadSceneAsync("UploadScene", LoadSceneMode.Additive);
 			else // 2. 로그인 버튼을 통해 들어온건가?
 				SceneManager.LoadSceneAsync("MenuScene", LoadSceneMode.Additive);
+			SceneManager.UnloadSceneAsync("LoginScene");
 		}
 		else
 		{


### PR DESCRIPTION
LoadSceneAsync의 위치를 아래로 두어, 보여질 신을 로드한 후에 사라질 신을 언로드함.  
Closes: #88 