### PR TITLE
Edit: 네비게이션의 목적지에 해당하는 매장 프리뷰의 높이값을 0으로 해야한다.

### DIFF
--- a/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
@@ -441,6 +441,7 @@ public class MaxstSceneManager : MonoBehaviour
 			print(Stores.ToArray().Length);
 			destVector.x = ((float)Stores[0].modifiedX);
 			destVector.y = ((float)Stores[0].modifiedY);
+			destVector.z = (float)0;
 			print(destVector.x);
 			print(destVector.y);
 			return destVector;


### PR DESCRIPTION
Vector3의 기본생상자 Vector3()는 (0,0,0)을 할당하기때문에 z값에 0을 할당하는 한줄의 코드는 실질적으로 프로그램에 영향을 끼치는 것은 아니다.  다만, 작업을 거치면서 issue 문제(#80)가 해결되어, 그 이유를 설명하고 닫고자 한다.  

https://github.com/2021-metaverse-developer-contest/co-ex/blob/1dd3b237f30f501fd298d3223b94cb023ea2dea7/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs#L495-L502 
1. `MakePath()` 함수에 넣어주는 목적지의 Vector는 전적으로 Trackable prefab의 위치 기준이다.
2. 같은 층의  매장은 모두 같은 높이에 있다는 가정(almost True)
3. 같은 층의 매장의 높이는 모두 2D_Maps -> **_Stores 의 position.y 값으로 제어해주는 것으로 한다.
4. 따라서, 목적지의 높이 값은 0을 넣고, 부모(**_Stores)에 따라서 global position.y가 변경되는 것을 이용하여 목적지의 Vector3 값을 함수에 제공한다.

Fix: #80 