### PR TITLE
Firebase 클래스들 수정 & 스토어 이름에 .이 들어간 경우 해결

### DIFF
--- a/coU/Assets/Resources/refresh_icon.png
+++ b/coU/Assets/Resources/refresh_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38db90c2069e57bf9be84c246e7a256ed64cc4ebf4c094285d3a2f394c44a111
+size 1081

--- a/coU/Assets/Resources/refresh_icon.png.meta
+++ b/coU/Assets/Resources/refresh_icon.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 8307e82aa3fbf44828fbe5aad49a8b9a
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/coU/Assets/Scene/Scenes/UploadScene.unity
+++ b/coU/Assets/Scene/Scenes/UploadScene.unity
@@ -240,7 +240,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &108097584
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -765,10 +765,10 @@ RectTransform:
   m_Father: {fileID: 1341310090}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 721.5, y: 0}
+  m_SizeDelta: {x: 718.5, y: 790}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &492094524
 MonoBehaviour:
@@ -4046,10 +4046,10 @@ RectTransform:
   m_Father: {fileID: 1341310090}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 718.5, y: 790}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1988948665
 MonoBehaviour:

--- a/coU/Assets/Scene/Scripts/DB/Firebase/StoreImg.cs
+++ b/coU/Assets/Scene/Scripts/DB/Firebase/StoreImg.cs
@@ -82,7 +82,7 @@ public class StoreImg
         this.dateTime = DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss");
         this.imgName = string.Format("{0}_{1}.{2}", this.dateTime, storeName, imgType);
         //
-        this.imgPath = Path.Combine(storeName, this.imgName);
+        this.imgPath = Path.Combine(storeName.Replace('.', '_'), this.imgName);
     }
 
     public void printAllValues()
@@ -107,7 +107,9 @@ public class StoreImg
 
     public string getfullPath(string firebasestorageURL)
     {
-        return Path.Combine(firebasestorageURL, imgPath);
+        string[] imgPaths = imgPath.Split('/');
+        imgPaths[0] = imgPaths[0].Replace('.', '_');
+        return Path.Combine(firebasestorageURL, imgPaths[0], imgPaths[1]);
     }
 
     public static void swapSortOrder(StoreImg a, StoreImg b) // 둘 사이 sortOrder 교환

--- a/coU/Assets/Scene/Scripts/FirebaseRealtimeManager.cs
+++ b/coU/Assets/Scene/Scripts/FirebaseRealtimeManager.cs
@@ -10,28 +10,18 @@ using UnityEngine.SceneManagement;
 
 public class FirebaseRealtimeManager
 {
-    private static FirebaseRealtimeManager _realtimeDB = null;
-    private static DatabaseReference dbReferecne = null;
+    //private static DatabaseReference dbReferecne = null;
+    private DatabaseReference dbReferecne = null;
 
     // Realtime DB의 값을 여기에 가져다 줌, FirebaseStorageManager에서는 void 꼴
     public User user = null;
     public StoreImg storeImg = null;
     public List<StoreImg> ListStoreImgs = new List<StoreImg>();
 
-    private FirebaseRealtimeManager()
+    public FirebaseRealtimeManager()
     {
         Debug.Log("Constructor of FirebaseRealtimeManager");
         dbReferecne = FirebaseDatabase.DefaultInstance.RootReference;
-    }
-
-    public static FirebaseRealtimeManager Instance
-    {
-        get
-        {
-            if (_realtimeDB == null)
-                _realtimeDB = new FirebaseRealtimeManager();
-            return _realtimeDB;
-        }
     }
 
     // 구현 안함
@@ -83,12 +73,12 @@ public class FirebaseRealtimeManager
                 // 값을 찾지 못해도 null 값이 들어감!
                 if (data == null)
                 {
-                    _realtimeDB.user = null;
+                    this.user = null;
                 }
                 else
                 {
-                    _realtimeDB.user = data as User;
-                    Debug.Log("storeName" + _realtimeDB.user.storeName);
+                    this.user = data as User;
+                    Debug.Log("storeName" + this.user.storeName);
                 }
 				wait.isDone = true;
             }
@@ -141,7 +131,8 @@ public class FirebaseRealtimeManager
 
     public void deleteStoreImgs(string storeName, WaitServer wait)
     {
-        dbReferecne.Child("StoreImg").Child(storeName).GetValueAsync().ContinueWith(task =>
+        string storeNameKey = storeName.Replace('.', '_');
+        dbReferecne.Child("StoreImg").Child(storeNameKey).GetValueAsync().ContinueWith(task =>
         {
             if (task.IsCanceled || task.IsFaulted)
                 Debug.Log("Error Delete StoreImgs: " + task.Exception);
@@ -174,7 +165,7 @@ public class FirebaseRealtimeManager
     public void createStoreImg(StoreImg newImg, WaitServer wait)
     {
         string json = JsonUtility.ToJson(newImg);
-        string key = newImg.storeName;
+        string key = newImg.storeName.Replace('.', '_');
         long idx = newImg.sortOrder;
         Debug.Log($"In CreateStoreImg key:{key}, idx:{idx}");
         Debug.Log($"Json {json}");
@@ -198,8 +189,9 @@ public class FirebaseRealtimeManager
     {
         ListStoreImgs.Clear();
         string table = typeof(StoreImg).Name;
+        string storeNameKey = storeName.Replace('.', '_');
         //dbReferecne.Child(table).Child(id).GetValueAsync().ContinueWithOnMainThread(task =>
-        dbReferecne.Child(table).Child(storeName).GetValueAsync().ContinueWith(task =>
+        dbReferecne.Child(table).Child(storeNameKey).GetValueAsync().ContinueWith(task =>
         {
             if (task.IsCanceled || task.IsFaulted)
             {

--- a/coU/Assets/Scene/Scripts/FirebaseStorageManager.cs
+++ b/coU/Assets/Scene/Scripts/FirebaseStorageManager.cs
@@ -12,20 +12,10 @@ using UnityEngine;
 
 public class FirebaseStorageManager
 {
-    private static FirebaseStorageManager _firebaseStorageManager;
-    public static FirebaseStorageManager Instance
-    {
-        get
-        {
-            if (_firebaseStorageManager == null)
-                _firebaseStorageManager = new FirebaseStorageManager();
-            return _firebaseStorageManager;
-        }
-    }
-
     private Firebase.Storage.FirebaseStorage firebaseStorage;
     private string firebasestorageURL;
-    private FirebaseStorageManager()
+    public Uri uri;
+    public FirebaseStorageManager()
     {
         firebaseStorage = Firebase.Storage.FirebaseStorage.DefaultInstance;
         firebasestorageURL = "gs://co-ex1.appspot.com";
@@ -95,7 +85,6 @@ public class FirebaseStorageManager
     }
 
     //public static Stream fileContents = null;
-    public static Uri uri;
 
     public void LoadFile(StoreImg storageData, WaitServer wait)
     {

--- a/coU/Assets/Scene/Scripts/ImgScrolling.cs
+++ b/coU/Assets/Scene/Scripts/ImgScrolling.cs
@@ -54,9 +54,10 @@ public class ImgScrolling : MonoBehaviour
 	IEnumerator ReadImgDB()
 	{
 		WaitServer wait = new WaitServer();
-		FirebaseRealtimeManager.Instance.readStoreImgs(StoreSceneManager.storeName, wait);
+		FirebaseRealtimeManager firebaseRealtime = new FirebaseRealtimeManager();
+		firebaseRealtime.readStoreImgs(StoreSceneManager.storeName, wait);
 		yield return wait.waitServer();
-		count = FirebaseRealtimeManager.Instance.ListStoreImgs.ToArray().Length;
+		count = firebaseRealtime.ListStoreImgs.ToArray().Length;
 		Debug.Log($"ImgScrolling count {count}");
 		movepos = imgWidth * (count - 1) / 2;
 		while (Vector2.Distance(content.localPosition, new Vector2(movepos, 0)) >= 0.1f)

--- a/coU/Assets/Scene/Scripts/LoginBtnClick.cs
+++ b/coU/Assets/Scene/Scripts/LoginBtnClick.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using TMPro;
@@ -17,9 +17,10 @@ public class LoginBtnClick : MonoBehaviour
 		GameObject panelPop = GameObject.Find("Canvas_Pop").transform.Find("Panel_PopWhole").gameObject;
 		TextMeshProUGUI tmpMsg = panelPop.transform.Find("Panel_Pop/TMP_Msg").GetComponent<TextMeshProUGUI>();
 		WaitServer wait = new WaitServer();
-		FirebaseRealtimeManager.Instance.readUser(LoginSceneManager.GetKeyFromEmail(loginId), wait);
+		FirebaseRealtimeManager firebaseRealtime = new FirebaseRealtimeManager();
+		firebaseRealtime.readUser(LoginSceneManager.GetKeyFromEmail(loginId), wait);
 		yield return wait.waitServer();
-		User loginUser = FirebaseRealtimeManager.Instance.user;
+		User loginUser = firebaseRealtime.user;
 		if (loginUser == null)
 		{
 			Debug.Log("아이디를 확인해주세요.");

--- a/coU/Assets/Scene/Scripts/RegisterBtnClick.cs
+++ b/coU/Assets/Scene/Scripts/RegisterBtnClick.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using TMPro;
@@ -19,9 +19,10 @@ public class RegisterBtnClick : MonoBehaviour
 	IEnumerator ChkDupEmail(TMP_InputField idField, TextMeshProUGUI txtMsg)
 	{
 		WaitServer wait = new WaitServer();
-		FirebaseRealtimeManager.Instance.readUser(LoginSceneManager.GetKeyFromEmail(idField.text), wait);
+		FirebaseRealtimeManager firebaseRealtime = new FirebaseRealtimeManager();
+		firebaseRealtime.readUser(LoginSceneManager.GetKeyFromEmail(idField.text), wait);
 		yield return wait.waitServer();
-		if (FirebaseRealtimeManager.Instance.user == null)
+		if (firebaseRealtime.user == null)
 		{
 			Debug.Log("No Duplication");
 			txtMsg.text = "사용 가능한 이메일입니다.";
@@ -46,7 +47,7 @@ public class RegisterBtnClick : MonoBehaviour
 	{
 		User newUser = new User(id, pw, storeName, 0);
 		WaitServer wait = new WaitServer();
-		FirebaseRealtimeManager.Instance.createUser(LoginSceneManager.GetKeyFromEmail(newUser.id), newUser, wait);
+		new FirebaseRealtimeManager().createUser(LoginSceneManager.GetKeyFromEmail(newUser.id), newUser, wait);
 		yield return wait.waitServer();
 		errMsg.text = "가입이 완료되었습니다.";
 		isDone = true;

--- a/coU/Assets/Scene/Scripts/Scene/LoginSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/LoginSceneManager.cs
@@ -27,8 +27,9 @@ public class LoginSceneManager : MonoBehaviour
 
 	public static string GetKeyFromEmail(string email)
     {
-        string[] ids = email.Split('@');
-        return (ids[0] + "_" + ids[1].Split('.')[0]).Replace('.', '_');
+        return email.Replace('.', '_').Replace('@', '_');
+        //string[] ids = email.Split('@');
+        //return (ids[0] + "_" + ids[1].Split('.')[0]).Replace('.', '_');
     }
 
     // UploadScene에 접근할 때 사용함

--- a/coU/Assets/Scene/Scripts/Scene/RegisterSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/RegisterSceneManager.cs
@@ -5,73 +5,13 @@ using TMPro;
 
 public class RegisterSceneManager : MonoBehaviour
 {
+    public static User user;
+
     // Start is called before the first frame update
     void Start()
     {
         Screen.orientation = ScreenOrientation.Portrait;
-        notDuplicatedId = false;
         user = null;
-    }
-
-    public static User user;
-    public string registerId;
-    public string registerPw;
-    public string registerPw2;
-    public string storeName;
-    private bool notDuplicatedId;
-
-    public bool checkPasswordCorrect()
-	{
-        if (registerPw == registerPw2)
-            return true;
-        else
-            return false;
-	}
-
-
-    public void RegisterCorutine()
-    {
-        StartCoroutine(Register());
-    }
-
-    public void checkDuplicatedCorutine()
-    {
-        StartCoroutine(checkDuplicated());
-    }
-
-    public IEnumerator checkDuplicated()
-	{
-		WaitServer wait = new WaitServer();
-        FirebaseRealtimeManager.Instance.readUser(registerId, wait);
-        yield return wait.waitServer();
-        User existUser = FirebaseRealtimeManager.Instance.user;
-        if (existUser != null)
-		{
-            notDuplicatedId = false;
-            Debug.Log("중복된 id가 있습니다.");
-		}
-        else
-        {
-            Debug.Log("중복된 id가 없습니다.");
-        }
-    }
-
-    public IEnumerator Register()
-    {
-        User newUser = new User(registerId, registerPw, storeName, 0);
-		WaitServer wait = new WaitServer();
-        FirebaseRealtimeManager.Instance.readUser(newUser.id, wait);
-        yield return wait.waitServer();
-        User existUser = FirebaseRealtimeManager.Instance.user;
-        if (existUser != null)
-            Debug.Log("중복된 id가 있습니다.");
-        else
-        {
-		    WaitServer wait2 = new WaitServer();
-            FirebaseRealtimeManager.Instance.createUser(newUser.id, newUser, wait2);
-            yield return wait2.waitServer();
-            Debug.Log($"{newUser.id}가 등록되었습니다.");
-        }
     }
 
     // Update is called once per frame

--- a/coU/Assets/Scene/Scripts/Scene/StoreSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/StoreSceneManager.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
@@ -123,9 +123,10 @@ public class StoreSceneManager : MonoBehaviour
     {
         string logoPath = store.logoPath.Substring(0, store.logoPath.LastIndexOf("."));
 		WaitServer wait = new WaitServer();
-        FirebaseRealtimeManager.Instance.readStoreImgs(storeName, wait);
+        FirebaseRealtimeManager firebaseRealtime = new FirebaseRealtimeManager();
+        firebaseRealtime.readStoreImgs(storeName, wait);
         yield return wait.waitServer();
-        count = FirebaseRealtimeManager.Instance.ListStoreImgs.ToArray().Length;
+        count = firebaseRealtime.ListStoreImgs.ToArray().Length;
         int idx = count == 0 ? 1 : count;
 
         for ( ; idx < imgs.Length; idx++)
@@ -140,16 +141,17 @@ public class StoreSceneManager : MonoBehaviour
         }
         else
 		{
-            FirebaseRealtimeManager.Instance.ListStoreImgs.Sort(StoreImg.sortOrdercmp);
+            firebaseRealtime.ListStoreImgs.Sort(StoreImg.sortOrdercmp);
             int i = 0;
 
-            foreach (StoreImg img in FirebaseRealtimeManager.Instance.ListStoreImgs)
+            foreach (StoreImg img in firebaseRealtime.ListStoreImgs)
             {
 		        WaitServer wait2 = new WaitServer();
-                FirebaseStorageManager.Instance.LoadFile(img, wait2);
+                FirebaseStorageManager firebaseStorage = new FirebaseStorageManager();
+                firebaseStorage.LoadFile(img, wait2);
                 yield return wait2.waitServer();
 
-                Uri uri = FirebaseStorageManager.uri;
+                Uri uri = firebaseStorage.uri;
                 UnityWebRequest www = UnityWebRequestTexture.GetTexture(uri);
                 yield return www.SendWebRequest();
                 if (www.isNetworkError || www.isHttpError)

--- a/coU/Assets/Scene/Scripts/Scene/UploadSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/UploadSceneManager.cs
@@ -19,7 +19,6 @@ public class UploadSceneManager : MonoBehaviour
 
 	public static List<StoreImg> ListStoreImgs;
 	public string storeName;
-	public string imgType;
 
 	private void Awake()
 	{
@@ -33,8 +32,7 @@ public class UploadSceneManager : MonoBehaviour
 	private void Start()
 	{
 		Screen.orientation = ScreenOrientation.Portrait;
-		GameObject.Find("TMP_StoreName").GetComponent<TextMeshProUGUI>().text = storeName;
-		//LoadCoroutine();
+		GameObject.Find("Panel_UploadCenter/TMP_StoreName").GetComponent<TextMeshProUGUI>().text = storeName;
 		itemParent = GameObject.Find("ContentUpload").transform;
 		ListStoreImgs.Clear();
 		init();
@@ -48,72 +46,14 @@ public class UploadSceneManager : MonoBehaviour
 		}
 	}
 
-	public void getDataCoroutine()
-	{
-		StartCoroutine(getData());
-	}
-
-	//public void downloadCoroutine()
-	//{
-	//	destFullPath = "/Users/yunslee/desttest.png";
-	//	StartCoroutine(Download());
-	//}
-
-	public void LoadCoroutine(string imgPath)
-	{
-		StartCoroutine(Load(imgPath));
-	}
-
-	//public IEnumerator Download()
-	//{
-	//	StoreImg data = new StoreImg(storeName, imgType, sortOrder);
-	//	FirebaseStorageManager.Instance.downloadFile(data, destFullPath);
-	//	yield return wait.waitServer();
-	//}
-
-	IEnumerator Load(string imgPath)
-	{
-		StoreImg data = new StoreImg(imgPath);
-		WaitServer wait = new WaitServer();
-		FirebaseStorageManager.Instance.LoadFile(data, wait);
-		yield return wait.waitServer();
-		Uri uri = FirebaseStorageManager.uri;
-		Image img = GetUIImage();
-		UnityWebRequest www = UnityWebRequestTexture.GetTexture(uri);
-		yield return www.SendWebRequest();
-		if (www.isNetworkError || www.isHttpError)
-			Debug.Log(www.error);
-		else
-		{
-			Texture2D texture = ((DownloadHandlerTexture)www.downloadHandler).texture;
-			img.sprite = Sprite.Create(texture, new Rect(0f, 0f, texture.width, texture.height), new Vector2(.5f, .5f));
-		}
-	}
-
-	public IEnumerator getData()
-	{
-		WaitServer wait = new WaitServer();
-		FirebaseRealtimeManager.Instance.readStoreImgs(LoginSceneManager.user.storeName, wait);
-		yield return wait.waitServer();
-	}
-
 	/// <summary>
 	/// Returns Image Component.
-	/// </summary>
 	/// <returns>Image component</returns>
+	/// </summary>
 	public static Image GetUIImage()
 	{
 		Debug.Log("This is Upload Image");
 		return GameObject.Find("Img_UploadImg").GetComponent<Image>();
-
-		//Texture2D newPhoto = new Texture2D(1, 1);
-		//byte[] imgData = new byte[fileContents.Length];
-		//newPhoto.LoadImage(imgData);
-		//newPhoto.Apply();
-		//Sprite sprite = Sprite.Create(newPhoto, new Rect(0, 0, newPhoto.width, newPhoto.height), new Vector2(.5f, .5f));
-		//img.sprite = sprite;,
-
-		//StartCoroutine(GetTexture(img, uri));
 	}
 
 	public void readStoreImgsCorutine()
@@ -125,9 +65,10 @@ public class UploadSceneManager : MonoBehaviour
 	{
 		//storeName = "계절밥상"; // Test를 위해서 Firebase에 맞게함. 실제로는 로그인 유저에 맞는 public storeName를 사용하면 됨.
 		WaitServer wait = new WaitServer();
-		FirebaseRealtimeManager.Instance.readStoreImgs(storeName, wait); //DB에 저장된 이미지들의 정보를 가져옴
+		FirebaseRealtimeManager firebaseRealtime = new FirebaseRealtimeManager();
+		firebaseRealtime.readStoreImgs(storeName, wait); //DB에 저장된 이미지들의 정보를 가져옴
 		yield return wait.waitServer();
-		ListStoreImgs = FirebaseRealtimeManager.Instance.ListStoreImgs;
+		ListStoreImgs = firebaseRealtime.ListStoreImgs;
 		print($"데이터 가져온 갯수: {ListStoreImgs.Count}");
 		ListStoreImgs.Sort(StoreImg.sortOrdercmp);
 		foreach (var i in ListStoreImgs)

--- a/coU/Assets/Scene/Scripts/Singleton/WaitServer.cs
+++ b/coU/Assets/Scene/Scripts/Singleton/WaitServer.cs
@@ -35,7 +35,10 @@ public class WaitServer
     {
         if (this.isLoadScene == true)
         {
-            SceneManager.LoadSceneAsync("LoadingScene", LoadSceneMode.Additive);
+            AsyncOperation asyncOper = SceneManager.LoadSceneAsync("LoadingScene", LoadSceneMode.Additive);
+
+            while (!asyncOper.isDone)
+                yield return null;
 
             //int index = SceneManager.sceneCount;
             //var op = SceneManager.LoadSceneAsync("LoadingScene", LoadSceneMode.Additive);

--- a/coU/Assets/Scene/Scripts/UploadBtnClick.cs
+++ b/coU/Assets/Scene/Scripts/UploadBtnClick.cs
@@ -12,8 +12,9 @@ public class UploadBtnClick : MonoBehaviour
 {
     [SerializeField]
     private GameObject item; //TMP_Item UI에 컨텐츠 이름 넣긴
+    List<StoreImg> listStoreImgs = new List<StoreImg>();
 
-    void uploadCoroutine(string srcFullPath)
+    void UploadCoroutine(string srcFullPath)
     {
         //srcFullPath = "/Users/yunslee/srctest.png";
         StartCoroutine(Upload(srcFullPath));
@@ -24,7 +25,8 @@ public class UploadBtnClick : MonoBehaviour
         string imgType = srcFullPath.Substring(srcFullPath.LastIndexOf(".") + 1);
         StoreImg data = new StoreImg(LoginSceneManager.user?.storeName, imgType, 0);
 		WaitServer wait = new WaitServer();
-        FirebaseStorageManager.Instance.uploadFile(data, srcFullPath, wait);
+        FirebaseStorageManager firebaseStorage = new FirebaseStorageManager();
+        firebaseStorage.uploadFile(data, srcFullPath, wait);
         yield return wait.waitServer();
         GameObject newItem = Instantiate(item, GameObject.Find("ContentUpload").transform);
         newItem.GetComponentInChildren<TextMeshProUGUI>().text = data.imgPath;
@@ -54,7 +56,7 @@ public class UploadBtnClick : MonoBehaviour
             Debug.Log("Image path: " + path);
             newPath = path;
 #if UNITY_EDITOR
-            uploadCoroutine(newPath);
+            UploadCoroutine(newPath);
 #elif UNITY_ANDROID
             uploadCoroutine("file://" + newPath);
 #endif
@@ -100,10 +102,11 @@ public class UploadBtnClick : MonoBehaviour
     {
         StoreImg data = new StoreImg(imgPath);
 		WaitServer wait = new WaitServer();
-        FirebaseStorageManager.Instance.LoadFile(data, wait);
+        FirebaseStorageManager firebaseStorage = new FirebaseStorageManager();
+        firebaseStorage.LoadFile(data, wait);
         yield return wait.waitServer();
 
-        Uri uri = FirebaseStorageManager.uri;
+        Uri uri = firebaseStorage.uri;
         Image img = UploadSceneManager.GetUIImage();
         Debug.Log("In coroutine " + uri.OriginalString);
         UnityWebRequest www = UnityWebRequestTexture.GetTexture(uri);
@@ -171,7 +174,8 @@ public class UploadBtnClick : MonoBehaviour
         Debug.Log($"ListCount {UploadSceneManager.ListStoreImgs.ToArray().Length}");
 
 		WaitServer wait = new WaitServer();
-        FirebaseRealtimeManager.Instance.deleteStoreImgs(LoginSceneManager.user.storeName, wait);
+        FirebaseRealtimeManager firebaseRealtime = new FirebaseRealtimeManager();
+        firebaseRealtime.deleteStoreImgs(LoginSceneManager.user.storeName, wait);
         yield return wait.waitServer();
 
         for (int i = 0; i < itemsParent.childCount; i++)
@@ -186,7 +190,7 @@ public class UploadBtnClick : MonoBehaviour
                     Debug.Log($"storeImg {storeImg.imgPath}");
                     storeImg.sortOrder = i;
 		            WaitServer wait2 = new WaitServer();
-                    FirebaseRealtimeManager.Instance.createStoreImg(storeImg, wait2);
+                    firebaseRealtime.createStoreImg(storeImg, wait2);
                     yield return wait2.waitServer();
                     UploadSceneManager.ListStoreImgs.Remove(storeImg);
                     break;
@@ -197,7 +201,7 @@ public class UploadBtnClick : MonoBehaviour
         {
             Debug.Log("Delete Storage?");
 		    WaitServer wait3 = new WaitServer();
-            FirebaseStorageManager.Instance.deleteFile(storeImg, wait3);
+            new FirebaseStorageManager().deleteFile(storeImg, wait3);
             yield return wait3.waitServer();
         }
 #if UNITY_EDITOR

--- a/coU/Assets/prefabs/MaxstScene/ImgScrollingMini.cs
+++ b/coU/Assets/prefabs/MaxstScene/ImgScrollingMini.cs
@@ -53,25 +53,27 @@ public class ImgScrollingMini : MonoBehaviour
 	{
 		Store store = GetDBData.getStoresData($"Select * from Stores where name = '{tmpStoreName.text}';")[0];
 		WaitServer wait = new WaitServer(isLoadScene: false);
-		FirebaseRealtimeManager.Instance.readStoreImgs(tmpStoreName.text, wait);
+		FirebaseRealtimeManager firebaseRealtime = new FirebaseRealtimeManager();
+		firebaseRealtime.readStoreImgs(tmpStoreName.text, wait);
 		yield return wait.waitServer();
-		count = FirebaseRealtimeManager.Instance.ListStoreImgs.ToArray().Length;
+		count = firebaseRealtime.ListStoreImgs.ToArray().Length;
 		int idx = count == 0 ? 1 : count;
 
 		for (; idx < imgs.Length; idx++)
 			imgs[idx].SetActive(false);
 		if (count > 0)
 		{
-			FirebaseRealtimeManager.Instance.ListStoreImgs.Sort(StoreImg.sortOrdercmp);
+			firebaseRealtime.ListStoreImgs.Sort(StoreImg.sortOrdercmp);
 			int i = 0;
 
-			foreach (StoreImg img in FirebaseRealtimeManager.Instance.ListStoreImgs)
+			foreach (StoreImg img in firebaseRealtime.ListStoreImgs)
 			{
 				WaitServer wait2 = new WaitServer(isLoadScene: false);
-				FirebaseStorageManager.Instance.LoadFile(img, wait2);
+				FirebaseStorageManager firebaseStorage = new FirebaseStorageManager();
+				firebaseStorage.LoadFile(img, wait2);
 				yield return wait2.waitServer();
 
-				Uri uri = FirebaseStorageManager.uri;
+				Uri uri = firebaseStorage.uri;
 				UnityWebRequest www = UnityWebRequestTexture.GetTexture(uri);
 				yield return www.SendWebRequest();
 				if (www.isNetworkError || www.isHttpError)


### PR DESCRIPTION
> FirebaseRealtimeManager나 FirebaseStorageManager의 static 변수에 여러 객체가 접근하여 필로소퍼같은 문제가 발생함.
이를 해결해주기 위해 싱글톤 패턴을 사용하지 않고 각각 객체 생성하여 사용하는 방법으로 바꿈

> 스토어 이름에 .이 들어간 경우 Firebase에 key에 .이 들어가면 안되기 때문에 이미지 경로(imgPath)에서 `/`를 기준으로 앞부분에 `.`이 들어가면 `_`로 바꿔줌