### PR TITLE
Feat: Arrow Prefab(=navi Track)과 안내 캐릭터 모션 변경

### DIFF
--- a/coU/Assets/MaxstAR/VPS/VPSStudio/Path/NavigationController.cs
+++ b/coU/Assets/MaxstAR/VPS/VPSStudio/Path/NavigationController.cs
@@ -385,19 +385,39 @@ public class NavigationController : MonoBehaviour
                 print($"{i}번째 track following");
                 if (i == count)
                     break;
-            }
-            else
+                #region Is there a navi Track in front of Character?
+                bool firstloop = true;
+				while (true)
+				{
+					if (naviTracks[i].activeSelf == false)
+					{
+                        if (firstloop == true)
+						{
+                            firstloop = false;
+                            stopMotion(animator, NavigationController.characterType);
+						}
+                        yield return null;
+					}
+					else
+					{
+                        if (NavigationController.characterType == e_character.rabbit)
+                        {
+                            animator.SetInteger("AnimIndex", 1);
+                            animator.SetTrigger("Next");
+                        }
+                        break;
+					}
+				}
+				#endregion
+			}
+			else
             {
-                // 나와의 거리가 가까운 경우
                 runMotion(animator, NavigationController.characterType);
                 dir = naviTracks[i].transform.position - character.transform.position;
                 dir.Normalize();
                 character.transform.position += dir * characterMoveSpeed * Time.deltaTime;
                 character.transform.forward = dir;
                 yield return null;
-                // 나와의 거리가 먼 경우
-                // 멈춰서(Motion Stop) 나를 기다리도록 구현해야 함
-
             }
         }
         stopMotion(animator, NavigationController.characterType);

--- a/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using maxstAR;
@@ -62,6 +62,10 @@ public class MaxstSceneManager : MonoBehaviour
 
 	//yunslee 2021.11.15
 	public TextMeshProUGUI floorTextBox;
+
+	// yunslee 2021.11.19
+	GameObject[] naviTrackArray;
+	public float trackVisableMaxRange = 25f;
 
 	void Awake()
 	{
@@ -230,10 +234,14 @@ public class MaxstSceneManager : MonoBehaviour
 			if (destination == null)
 			{
 				if (GameObject.Find("destination") != null)
+				{
 					destination = GameObject.Find("destination").gameObject;
+					naviTrackArray = GameObject.FindGameObjectsWithTag("naviTrack");
+				}
 			}
 			if (destination != null) //else가 아닌 이유: destination 찾자마자 실행되어야하므
 				destination.transform.forward = arCamera.transform.forward;
+			updateVisibleTrack();
 		}
 
 		TrackerManager.GetInstance().UpdateFrame();
@@ -648,5 +656,23 @@ public class MaxstSceneManager : MonoBehaviour
     private void OnDisable()
     {
 		vPSTrackablesList = null;
+	}
+
+	public void updateVisibleTrack()
+	{
+		foreach (GameObject eachArrowItem in naviTrackArray)
+		{
+			Vector3 arCameraPosition = arCamera.transform.position;
+			Vector3 arrowPosition = eachArrowItem.transform.position;
+			float distacne = Vector3.Distance(arCameraPosition, arrowPosition);
+			if (distacne > trackVisableMaxRange)
+			{
+				eachArrowItem.SetActive(false);
+			}
+			else
+			{
+				eachArrowItem.SetActive(true);
+			}
+		}
 	}
 }


### PR DESCRIPTION
1. Arrow prefab이 화면이 나타나는 갯수가 Overhead의 원인이 될 수 있다는 생각에 보여지는 갯수를 제한함. `public float naviVisableMaxRange` (https://github.com/2021-metaverse-developer-contest/co-ex/issues/126#issuecomment-973827750). 
    <img width="819" alt="스크린샷 2021-11-19 오후 5 25 55" src="https://user-images.githubusercontent.com/56223639/142590593-a868651c-c7b0-44e0-89fc-c05108714869.png">
내 위치에서 25 만큼의 Navi Track만 active됨.

2. 안내 캐릭터가 사용자를 기다려주는 모션을 추가함. 그 원리는 사용자와의 위치를 계산하는 것이 아니라 캐릭터 앞에 navi Track이 없으면 움직이지 않고, 캐릭터 앞에 navi Track이 존재하면 계속해서 전진한다.