### PR TITLE
Fix: 공간 인식 오래걸림, 워터마크 문제 해결

### DIFF
--- a/coU/Assets/Scene/Scripts/PutMarkerManager.cs
+++ b/coU/Assets/Scene/Scripts/PutMarkerManager.cs
@@ -52,6 +52,8 @@ public class PutMarkerManager : MonoBehaviour
     {
         foreach (GameObject canvas in canvasList)
         {
+            if (canvas == null)
+                break;
             if (isValidDistance(canvas.transform.position) == true)
             {
                 canvas.SetActive(true);
@@ -104,14 +106,15 @@ public class PutMarkerManager : MonoBehaviour
         if (isfinishDetect == false)
         {
             if (GameObject.Find("Canvas_Overlay").transform.Find("Panel_Background").gameObject.active == false)
-                isfinishDetect = true;
-            if (isfinishDetect == true)
-            {
+			{
                 timetoDraw();
-            }
+                isfinishDetect = true;
+			}
         }
-        if (isfinishDetect == true)
+        else
+		{
             drawTransparent();
+		}
     }
 
     private bool isValidDistance(Vector3 storePosition)
@@ -208,23 +211,23 @@ public class PutMarkerManager : MonoBehaviour
         return (arTransform);
     }
 
-    //bool isPause = false;
-
-    //private void OnApplicationPause(bool pause)
-    //{
-    //    if (pause)
-    //    {
-    //        isPause = true;           
-    //        foreach (var i in GameObject.FindGameObjectsWithTag("minicanvas"))
-    //            Destroy(i);
-    //        canvasList.Clear();
-    //    }
-    //    else
-    //    {
-    //        if (isPause)
-    //            isfinishDetect = false;
-    //        isPause = false;
-    //    }
-
-    //}
+    // 혹시 몰라서 멤버변수 canvasList를 날림
+	private void OnApplicationPause(bool pause)
+	{
+		if (pause)
+		{
+		}
+		else
+		{
+            isfinishDetect = false;
+            if (canvasList.Count != 0)
+            {
+                foreach (var i in canvasList)
+                {
+                    Destroy(i);
+                }
+            }
+            canvasList.Clear();
+		}
+	}
 }

--- a/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
+++ b/coU/Assets/Scene/Scripts/Scene/MaxstSceneManager.cs
@@ -333,7 +333,7 @@ public class MaxstSceneManager : MonoBehaviour
 				#if UNITY_EDITOR
 					Debug.Log(toastMessage);
 				#elif UNITY_ANDROID && !UNITY_EDITOR
-					Toast.ShowToastMessage(toastMessage, 8000);
+					StartCoroutine(Toast.ShowToastMessageCoroutine(toastMessage, 15000));
 				#endif
 			}
 		}
@@ -379,6 +379,7 @@ public class MaxstSceneManager : MonoBehaviour
 		{
 			CameraDevice.GetInstance().Stop();
 			TrackerManager.GetInstance().StopTracker();
+			SceneManager.LoadScene("MaxstScene");
 		}
 		else
 		{

--- a/coU/Assets/Scene/Scripts/Singleton/Toast.cs
+++ b/coU/Assets/Scene/Scripts/Singleton/Toast.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Threading;
 using UnityEngine;
 
@@ -23,6 +24,30 @@ public class Toast
                 toast.Call("show");
             }));
             Thread.Sleep(showTime);
+            unityActivity.Call("runOnUiThread", new AndroidJavaRunnable(() =>
+            {
+                toast.Call("cancel");
+            }));
+        }
+#endif
+    }
+
+
+    public static IEnumerator ShowToastMessageCoroutine(string message, int showTime)
+    {
+#if UNITY_ANDROID
+        AndroidJavaClass unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+        AndroidJavaObject unityActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+        AndroidJavaClass toastClass = new AndroidJavaClass("android.widget.Toast");
+        AndroidJavaObject toast = toastClass.CallStatic<AndroidJavaObject>("makeText", unityActivity, message, 0);
+
+        if (unityActivity != null)
+        {
+            unityActivity.Call("runOnUiThread", new AndroidJavaRunnable(() =>
+            {
+                toast.Call("show");
+            }));
+            yield return new WaitForSeconds(showTime / 1000.0f);
             unityActivity.Call("runOnUiThread", new AndroidJavaRunnable(() =>
             {
                 toast.Call("cancel");


### PR DESCRIPTION
## 수정사항
1. Toast에서 사용하는 Thread.Sleep() 이 병목현상을 야기함 -> Toast 메세지를 코루틴으로 오래 띄울 수 있도록 수정함
2. MaxstScene에서 앱 실행 도중에 나갔다 오는 경우, 단순하게 MaxstScene 다시 로드하는 방식으로 수정함

Fix: #61 